### PR TITLE
ensure Lager is compiled before requiring it

### DIFF
--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -1,3 +1,5 @@
+Code.ensure_compiled(Lager)
+
 defmodule Facebook.Graph do
 	require Lager
 


### PR DESCRIPTION
Ran into a few scenarios where this would not be available in time to require in the macros. Happens with Elixir 0.13/0.14. Didn't see this in Elixir 0.12.
