### PR TITLE
Fix crash on request failure cases

### DIFF
--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -56,11 +56,15 @@ defmodule Facebook.Graph do
 	@spec request(method, url, payload, options) :: response
 	defp request(method, url, payload, options) do
 		headers = []
-		Logger.info("[#{method}] #{url} #{inspect headers} #{inspect payload}")
+		Logger.info fn ->
+			"[#{method}] #{url} #{inspect headers} #{inspect payload}"
+		end
 		case :hackney.request(method, url, headers, payload, options) do
 			{:ok, _status_code, _headers, client_ref} ->
 				{:ok, body} = :hackney.body(client_ref)
-				Logger.info("body: #{body}")
+				Logger.info fn ->
+					"body: #{inspect body}"
+				end
 				case JSON.decode(body) do
 					{:ok, data} ->
 						{:json, data}
@@ -68,7 +72,9 @@ defmodule Facebook.Graph do
 						{:body, body}
 				end
 			error ->
-				Logger.error("error: #{error}")
+				Logger.error fn ->
+					"error: #{inspect error}"
+				end
 				error
 		end
 	end


### PR DESCRIPTION
An error tuple is returned from hackney requests and must be inspected because a tuple does not implement the String.Chars protocol.

```elixir
06:45:59.184 [error] GenServer #PID<0.697.2> terminating
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:error, :closed}
        (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
        (elixir) lib/string/chars.ex:17: String.Chars.to_string/1
        (facebook) lib/facebook/graph.ex:71: Facebook.Graph.request/4
        (tu_account) lib/tu_account/facebook.ex:8: TUAccount.Facebook.fetch_facebook_id/1
        (tu_account) lib/tu_account/dispatcher.ex:34: TUAccount.Dispatcher.handle_message/1
        (tu_net) lib/tu_net/dispatcher/worker.ex:69: TUNet.Dispatcher.Worker.handle_message/2
        (stdlib) timer.erl:194: :timer.tc/3
        (tu_net) lib/tu_net/dispatcher/worker.ex:114: TUNet.Dispatcher.Worker.handle_info/2
```

This PR inspects the error tuple and delays logger action for calls to logger with interpolated messages.