### PR TITLE
Updating version of json package, with a resolved bug

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -1,170 +1,170 @@
 defmodule Facebook do
-	use Application
-	use Supervisor
+  use Application
+  use Supervisor
 
-	@moduledoc """
-	Provides API wrappers for the Facebook Graph API
+  @moduledoc """
+  Provides API wrappers for the Facebook Graph API
 
-	See: https://developers.facebook.com/docs/graph-api
-	"""
+  See: https://developers.facebook.com/docs/graph-api
+  """
 
-	alias Facebook.Config
+  alias Facebook.Config
 
-	@doc "Start hook"
-	def start(_type, _args) do
-		start_link([])
-	end
+  @doc "Start hook"
+  def start(_type, _args) do
+    start_link([])
+  end
 
-	@doc "Supervisor start"
-	def start_link(_) do
-		Supervisor.start_link(__MODULE__, [])
-	end
+  @doc "Supervisor start"
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [])
+  end
 
-	def init(_) do
-		children = [
-			worker(Facebook.Graph, [])
-		]
+  def init(_) do
+    children = [
+      worker(Facebook.Graph, [])
+    ]
 
-		supervise(children, strategy: :one_for_one)
-	end
+    supervise(children, strategy: :one_for_one)
+  end
 
-	@type fields :: list
-	@type access_token :: String.t
-	@type response :: {:json, HashDict.t} | {:body, String.t}
-	@type options :: list
-	@type using_appsecret :: boolean
+  @type fields :: list
+  @type access_token :: String.t
+  @type response :: {:json, HashDict.t} | {:body, String.t}
+  @type options :: list
+  @type using_appsecret :: boolean
 
-	@doc """
-	If you want to use an appsecret proof, pass it into set_appsecret:
-	Facebook.set_appsecret("appsecret")
+  @doc """
+  If you want to use an appsecret proof, pass it into set_appsecret:
+  Facebook.set_appsecret("appsecret")
 
-	See: https://developers.facebook.com/docs/graph-api/securing-requests
-	"""
-	def set_appsecret(appsecret) do
-		Config.appsecret(appsecret)
-	end
+  See: https://developers.facebook.com/docs/graph-api/securing-requests
+  """
+  def set_appsecret(appsecret) do
+    Config.appsecret(appsecret)
+  end
 
-	@doc """
-	Basic user infos of the logged in user (specified by the access_token)
+  @doc """
+  Basic user infos of the logged in user (specified by the access_token)
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/
-	"""
-	@spec me(fields, access_token) :: response
-	def me(fields, access_token) when is_binary(fields) do
-		me([fields: fields], access_token, [])
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/
+  """
+  @spec me(fields, access_token) :: response
+  def me(fields, access_token) when is_binary(fields) do
+    me([fields: fields], access_token, [])
+  end
 
-	def me(fields, access_token) do
-		me(fields, access_token, [])
-	end
+  def me(fields, access_token) do
+    me(fields, access_token, [])
+  end
 
-	@doc """
-	Basic user infos of the logged in user (specified by the access_token).
+  @doc """
+  Basic user infos of the logged in user (specified by the access_token).
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/
-	"""
-	@spec me(fields :: String.t, access_token, options) :: response
-	def me(fields, access_token, options) when is_binary(fields) do
-		me([fields: fields], access_token, options)
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/
+  """
+  @spec me(fields :: String.t, access_token, options) :: response
+  def me(fields, access_token, options) when is_binary(fields) do
+    me([fields: fields], access_token, options)
+  end
 
-	@doc """
-	Basic user infos of the logged in user (specified by the access_token).
+  @doc """
+  Basic user infos of the logged in user (specified by the access_token).
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/
-	"""
-	@spec me(fields, access_token, options) :: response
-	def me(fields, access_token, options) do
-		if !is_nil(Config.appsecret) do
-			fields = fields ++ [appsecret_proof: encrypt(access_token)]
-		end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/
+  """
+  @spec me(fields, access_token, options) :: response
+  def me(fields, access_token, options) do
+    if !is_nil(Config.appsecret) do
+      fields = fields ++ [appsecret_proof: encrypt(access_token)]
+    end
 
-		Facebook.Graph.get("/me", fields ++ [access_token: access_token], options)
-	end
+    Facebook.Graph.get("/me", fields ++ [access_token: access_token], options)
+  end
 
-	@doc """
-	Likes of the currently logged in user (specified by the access_token)
+  @doc """
+  Likes of the currently logged in user (specified by the access_token)
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/likes
-	"""
-	@spec myLikes(access_token) :: response
-	def myLikes(access_token) do
-		myLikes(access_token, [])
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/likes
+  """
+  @spec myLikes(access_token) :: response
+  def myLikes(access_token) do
+    myLikes(access_token, [])
+  end
 
-	@doc """
-	Likes of the currently logged in user (specified by the access_token)
+  @doc """
+  Likes of the currently logged in user (specified by the access_token)
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/likes
-	"""
-	@spec myLikes(access_token, options) :: response
-	def myLikes(access_token, options) do
-		fields = [access_token: access_token]
-		if !is_nil(Config.appsecret) do
-			fields = fields ++ [appsecret_proof: encrypt(access_token)]
-		end
-		Facebook.Graph.get("/me/likes", fields, options)
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/likes
+  """
+  @spec myLikes(access_token, options) :: response
+  def myLikes(access_token, options) do
+    fields = [access_token: access_token]
+    if !is_nil(Config.appsecret) do
+      fields = fields ++ [appsecret_proof: encrypt(access_token)]
+    end
+    Facebook.Graph.get("/me/likes", fields, options)
+  end
 
-	@doc """
-	Retrieves a list of granted permissions
+  @doc """
+  Retrieves a list of granted permissions
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/permissions
-	"""
-	@spec permissions(user_id :: integer | String.t, access_token) :: response
-	def permissions(user_id, access_token) do
-		permissions(user_id, access_token, [])
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/permissions
+  """
+  @spec permissions(user_id :: integer | String.t, access_token) :: response
+  def permissions(user_id, access_token) do
+    permissions(user_id, access_token, [])
+  end
 
-	@doc """
-	Retrieves a list of granted permissions
+  @doc """
+  Retrieves a list of granted permissions
 
-	See: https://developers.facebook.com/docs/graph-api/reference/user/permissions
-	"""
-	@spec permissions(user_id :: integer | String.t, access_token, options) :: response
-	def permissions(user_id, access_token, options) do
-		fields = [access_token: access_token]
-		if !is_nil(Config.appsecret) do
-			fields = fields ++ [appsecret_proof: encrypt(access_token)]
-		end
-		Facebook.Graph.get(~s(/#{user_id}/permissions), fields, options)
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/user/permissions
+  """
+  @spec permissions(user_id :: integer | String.t, access_token, options) :: response
+  def permissions(user_id, access_token, options) do
+    fields = [access_token: access_token]
+    if !is_nil(Config.appsecret) do
+      fields = fields ++ [appsecret_proof: encrypt(access_token)]
+    end
+    Facebook.Graph.get(~s(/#{user_id}/permissions), fields, options)
+  end
 
-	@doc """
-	Get the number of likes for the provided page_id
-	"""
-	@spec pageLikes(page_id :: integer | String.t, access_token) :: integer
-	def pageLikes(page_id, access_token) do
-		{:json, %{"likes" => likes}} = page(page_id, access_token, ["likes"], [])
-		likes
-	end
+  @doc """
+  Get the number of likes for the provided page_id
+  """
+  @spec pageLikes(page_id :: integer | String.t, access_token) :: integer
+  def pageLikes(page_id, access_token) do
+    {:json, %{"likes" => likes}} = page(page_id, access_token, ["likes"], [])
+    likes
+  end
 
-	@doc """
-	Basic page information for the provided page_id
+  @doc """
+  Basic page information for the provided page_id
 
-	See: https://developers.facebook.com/docs/graph-api/reference/page
-	"""
-	@spec page(page_id :: integer | String.t, access_token) :: response
-	def page(page_id, access_token) do
-		page(page_id, access_token, [], [])
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/page
+  """
+  @spec page(page_id :: integer | String.t, access_token) :: response
+  def page(page_id, access_token) do
+    page(page_id, access_token, [], [])
+  end
 
-	@doc """
-	Get page information for the specified fields for the provided page_id
+  @doc """
+  Get page information for the specified fields for the provided page_id
 
-	See: https://developers.facebook.com/docs/graph-api/reference/page
-	"""
-	@spec page(page_id :: integer | String.t, access_token, fields, options) :: response
-	def page(page_id, access_token, fields, options) do
-		params = [fields: fields, access_token: access_token]
-		if !is_nil(Config.appsecret) do
-			params = params ++ [appsecret_proof: encrypt(access_token)]
-		end
-		Facebook.Graph.get(~s(/#{page_id}), params, options)
-	end
+  See: https://developers.facebook.com/docs/graph-api/reference/page
+  """
+  @spec page(page_id :: integer | String.t, access_token, fields, options) :: response
+  def page(page_id, access_token, fields, options) do
+    params = [fields: fields, access_token: access_token]
+    if !is_nil(Config.appsecret) do
+      params = params ++ [appsecret_proof: encrypt(access_token)]
+    end
+    Facebook.Graph.get(~s(/#{page_id}), params, options)
+  end
 
 
-	defp encrypt(token) do
-		:hmac.hexlify(:crypto.hmac(:sha256, Config.appsecret, token), [:string, :lower])
-	end
+  defp encrypt(token) do
+    :hmac.hexlify(:crypto.hmac(:sha256, Config.appsecret, token), [:string, :lower])
+  end
 end

--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -1,81 +1,81 @@
 defmodule Facebook.Graph do
-	require Logger
+  require Logger
 
-	alias Facebook.Config
+  alias Facebook.Config
 
-	@moduledoc """
-	HTTP Wrapper for the Graph API using hackney.
-	"""
+  @moduledoc """
+  HTTP Wrapper for the Graph API using hackney.
+  """
 
-	@doc """
-	Start the API
-	"""
-	@spec start_link :: :ok
-	def start_link do
-		:ignore
-	end
+  @doc """
+  Start the API
+  """
+  @spec start_link :: :ok
+  def start_link do
+    :ignore
+  end
 
-	@type path :: String.t
-	@type response :: {:json, HashDict.t} | {:body, String.t}
-	@type options :: list
-	@type params :: list
-	@type method :: :get | :post | :put | :head
-	@type url :: String.t
-	@type payload :: binary
+  @type path :: String.t
+  @type response :: {:json, HashDict.t} | {:body, String.t}
+  @type options :: list
+  @type params :: list
+  @type method :: :get | :post | :put | :head
+  @type url :: String.t
+  @type payload :: binary
 
-	@doc """
-	HTTP GET using a path
-	"""
-	@spec get(path) :: response
-	def get(path) do
-		get(path, [], [])
-	end
+  @doc """
+  HTTP GET using a path
+  """
+  @spec get(path) :: response
+  def get(path) do
+    get(path, [], [])
+  end
 
-	@doc """
-	HTTP GET using path and params
-	"""
-	@spec get(path, params) :: response
-	def get(path, params) do
-		get(path, params, [])
-	end
+  @doc """
+  HTTP GET using path and params
+  """
+  @spec get(path, params) :: response
+  def get(path, params) do
+    get(path, params, [])
+  end
 
-	@doc """
-	HTTP GET using path, params and options
-	"""
-	@spec get(path, params, options) :: response
-	def get(path, params, options) do
-		url = :hackney_url.make_url(Config.graph_url, path, params)
-		request(:get, url, options)
-	end
+  @doc """
+  HTTP GET using path, params and options
+  """
+  @spec get(path, params, options) :: response
+  def get(path, params, options) do
+    url = :hackney_url.make_url(Config.graph_url, path, params)
+    request(:get, url, options)
+  end
 
-	@spec request(method, url, options) :: response
-	defp request(method, url, options) do
-		request(method, url, <<>>, options)
-	end
+  @spec request(method, url, options) :: response
+  defp request(method, url, options) do
+    request(method, url, <<>>, options)
+  end
 
-	@spec request(method, url, payload, options) :: response
-	defp request(method, url, payload, options) do
-		headers = []
-		Logger.info fn ->
-			"[#{method}] #{url} #{inspect headers} #{inspect payload}"
-		end
-		case :hackney.request(method, url, headers, payload, options) do
-			{:ok, _status_code, _headers, client_ref} ->
-				{:ok, body} = :hackney.body(client_ref)
-				Logger.info fn ->
-					"body: #{inspect body}"
-				end
-				case JSON.decode(body) do
-					{:ok, data} ->
-						{:json, data}
-					_ ->
-						{:body, body}
-				end
-			error ->
-				Logger.error fn ->
-					"error: #{inspect error}"
-				end
-				error
-		end
-	end
+  @spec request(method, url, payload, options) :: response
+  defp request(method, url, payload, options) do
+    headers = []
+    Logger.info fn ->
+      "[#{method}] #{url} #{inspect headers} #{inspect payload}"
+    end
+    case :hackney.request(method, url, headers, payload, options) do
+      {:ok, _status_code, _headers, client_ref} ->
+        {:ok, body} = :hackney.body(client_ref)
+        Logger.info fn ->
+          "body: #{inspect body}"
+        end
+        case JSON.decode(body) do
+          {:ok, data} ->
+            {:json, data}
+          _ ->
+            {:body, body}
+        end
+      error ->
+        Logger.error fn ->
+          "error: #{inspect error}"
+        end
+        error
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,68 +1,68 @@
 Code.ensure_loaded?(Hex) and Hex.start
 
 defmodule Facebook.Mixfile do
-	use Mix.Project
+  use Mix.Project
 
-	def project do
-		[
-			app: :facebook,
-			version: "0.4.0",
-			elixir: "~> 1.0",
-			description: description,
-			package: package,
-			deps: deps,
-			source_url: "https://github.com/mweibel/facebook.ex"
-		]
-	end
+  def project do
+    [
+      app: :facebook,
+      version: "0.4.0",
+      elixir: "~> 1.0",
+      description: description,
+      package: package,
+      deps: deps,
+      source_url: "https://github.com/mweibel/facebook.ex"
+    ]
+  end
 
-	# Configuration for the OTP application
-	def application do
-		[
-			mod: { Facebook, [] },
-			applications: [:json, :hackney, :logger],
-			env: [
-				env: :dev,
-				graph_url: "https://graph.facebook.com/v2.0",
-				appsecret: nil
-			]
-		]
-	end
+  # Configuration for the OTP application
+  def application do
+    [
+      mod: { Facebook, [] },
+      applications: [:json, :hackney, :logger],
+      env: [
+        env: :dev,
+        graph_url: "https://graph.facebook.com/v2.0",
+        appsecret: nil
+      ]
+    ]
+  end
 
-	defp description do
-		"""
-		Facebook Graph API Wrapper written in Elixir.
-		Please note, this is very much a work in progress. Feel free to contribute using pull requests.
-		"""
-	end
+  defp description do
+    """
+    Facebook Graph API Wrapper written in Elixir.
+    Please note, this is very much a work in progress. Feel free to contribute using pull requests.
+    """
+  end
 
-	defp package do
-		[
-			licenses: ["MIT"],
-			links: %{
-				"GitHub" => "https://github.com/mweibel/facebook.ex"
-			},
-			contributors: [
-				"Michael Weibel",
-				"Garrett Amini",
-				"Jamie Winsor",
-				"Adam Solove"
-			]
-		]
-	end
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/mweibel/facebook.ex"
+      },
+      contributors: [
+        "Michael Weibel",
+        "Garrett Amini",
+        "Jamie Winsor",
+        "Adam Solove"
+      ]
+    ]
+  end
 
-	# Returns the list of dependencies in the format:
-	# { :foobar, git: "https://github.com/elixir-lang/foobar.git", tag: "0.1" }
-	#
-	# To specify particular versions, regardless of the tag, do:
-	# { :barbat, "~> 0.1", github: "elixir-lang/barbat" }
-	defp deps do
-		[
-			{:json, ">= 0.3.0"},
-			{:hackney, "~> 1.0"},
-			{:libex_config, ">= 0.1.0"},
-			{:erlsha2, github: "vinoski/erlsha2", tag: "2.1"},
-			{:earmark, "~> 0.1", only: :dev},
-			{:ex_doc, "~> 0.6", only: :dev}
-		]
-	end
+  # Returns the list of dependencies in the format:
+  # { :foobar, git: "https://github.com/elixir-lang/foobar.git", tag: "0.1" }
+  #
+  # To specify particular versions, regardless of the tag, do:
+  # { :barbat, "~> 0.1", github: "elixir-lang/barbat" }
+  defp deps do
+    [
+      {:json, ">= 0.3.3"},
+      {:hackney, "~> 1.0"},
+      {:libex_config, ">= 0.1.0"},
+      {:erlsha2, github: "vinoski/erlsha2", tag: "2.1"},
+      {:earmark, "~> 0.1", only: :dev},
+      {:ex_doc, "~> 0.6", only: :dev}
+    ]
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Facebook.Mixfile do
   def project do
     [
       app: :facebook,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.0",
       description: description,
       package: package,

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -1,7 +1,7 @@
 defmodule FacebookTest do
-	use ExUnit.Case
+  use ExUnit.Case
 
-	test "the truth" do
-		assert(true)
-	end
+  test "the truth" do
+    assert(true)
+  end
 end


### PR DESCRIPTION
The problem with the 0.3.2 version of json package is that it raises an exception when trying to decode emojis, that turns out, are very common in Facebook posts and comments. The version 0.3.3 has this error fixed. I hope you can merge this soon, thank you!
I also changed the tab indentation to spaces as recommended in the elixir style guides. an Finally I bumped the version of this package.