### PR TITLE
Fixed: Object likes

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -220,28 +220,6 @@ defmodule Facebook do
   If you want to get the likes of a page, please see *pageLikes*.
 
   ## Example
-      iex> Facebook.objectLikes("1326382730725053_1326476257382367", "<Token>")
-      2
-
-  See: developers.facebook.com/docs/graph-api/reference/object/likes
-  """
-  def objectLikes(object_id, access_token) do
-    likes_count = fn
-      {:json, %{"error" => error}} -> %{:error => error}
-      {:json, info_map} ->
-        info_map
-          |> Map.fetch!("summary")
-          |> Map.fetch!("total_count")
-    end
-  end
-
-  @doc """
-  Gets the total number of people who liked an object.
-  An *object* stands for: post, comment, link, status update, photo.
-
-  If you want to get the likes of a page, please see *pageLikes*.
-
-  ## Example
       iex> Facebook.objectCount(:likes, "1326382730725053_1326476257382367", "<Token>")
       2
 

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -228,8 +228,8 @@ defmodule Facebook do
   def objectCount(:likes, object_id, access_token) do
     :likes
       |> Atom.to_string
-      |> _objectSummary(object_id, access_token)
-      |> _summaryCount
+      |> objectSummary(object_id, access_token)
+      |> summaryCount
   end
 
   @doc """
@@ -245,8 +245,8 @@ defmodule Facebook do
   def objectCount(:comments, object_id, access_token) do
     :comments
       |> Atom.to_string
-      |> _objectSummary(object_id, access_token)
-      |> _summaryCount
+      |> objectSummary(object_id, access_token)
+      |> summaryCount
   end
 
   """

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -213,6 +213,37 @@ defmodule Facebook do
     Facebook.Graph.get(~s(/#{page_id}/feed), params)
   end
 
+  @doc """
+  Gets the total number of people who liked an object.
+  An *object* stands for: post, comment, link, status update, photo.
+
+  If you want to get the likes of a page, please see *pageLikes*.
+
+  ## Example
+      iex> Facebook.objectLikes("1326382730725053_1326476257382367", "<Token>")
+      2
+
+  See: developers.facebook.com/docs/graph-api/reference/object/likes
+  """
+  def objectLikes(object_id, access_token) do
+    likes_count = fn
+      {:json, %{"error" => error}} -> %{:error => error}
+      {:json, info_map} ->
+        info_map
+          |> Map.fetch!("summary")
+          |> Map.fetch!("total_count")
+    end
+
+    params = [access_token: access_token, summary: true]
+    if !is_nil(Config.appsecret) do
+      params = params ++ [appsecret_proof: encrypt(access_token)]
+    end
+
+    Facebook.Graph.get(~s(/#{object_id}/likes), params)
+      |> likes_count.()
+
+  end
+
   defp encrypt(token) do
     :crypto.hmac(:sha256, Config.appsecret, token)
     |> Base.encode16(case: :lower)

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -226,8 +226,7 @@ defmodule Facebook do
   See: https://developers.facebook.com/docs/graph-api/reference/object/likes
   """
   def objectCount(:likes, object_id, access_token) do
-    :likes
-      |> Atom.to_string
+    "likes"
       |> objectSummary(object_id, access_token)
       |> summaryCount
   end
@@ -243,8 +242,7 @@ defmodule Facebook do
   See: https://developers.facebook.com/docs/graph-api/reference/object/comments
   """
   def objectCount(:comments, object_id, access_token) do
-    :comments
-      |> Atom.to_string
+    "comments"
       |> objectSummary(object_id, access_token)
       |> summaryCount
   end

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -257,7 +257,7 @@ defmodule Facebook do
       iex> _objectSummary("comments", "1326382730725053_1326476257382367", "<Token>")
       %{"total_count" => 47}
   """
-  defp _objectSummary(scope, object_id, access_token) do
+  defp objectSummary(scope, object_id, access_token) do
       summary = fn
         {:json, %{"error" => error}} -> %{:error => error}
         {:json, info_map} ->
@@ -277,12 +277,12 @@ defmodule Facebook do
   """
   Gets the 'total_count' attribute from a summary request.
   """
-  defp _summaryCount(%{"total_count" => count}), do: count
+  defp summaryCount(%{"total_count" => count}), do: count
 
   """
   Returns a error if the summary requests failed.
   """
-  defp _summaryCount(%{"error" => error}), do: error
+  defp summaryCount(%{"error" => error}), do: error
 
   defp encrypt(token) do
     :crypto.hmac(:sha256, Config.appsecret, token)


### PR DESCRIPTION
**Pull request fixed!**

I wrote a function to get the total number of people who liked an object.
An "object" stands for: post, comment, link, status update, photo and so on.

This function is: objectLikes/2

The object is searched by its id and then the number of likes is retrieved.