### PR TITLE
pageFeed enhanced!

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -204,27 +204,12 @@ defmodule Facebook do
   ## Examples
       iex> Facebook.pageFeed(:posts, "CocaColaMx", "<Your Token>")
       iex> Facebook.pageFeed(:tagged, "CocaColaMx", "<Your Token>", 55)
-      iex> Facebook.pageFeed(:promotable, "CocaColaMx", "<Your Token>")
+      iex> Facebook.pageFeed(:promotable_posts, "CocaColaMx", "<Your Token>")
       iex> Facebook.pageFeed(:feed, "CocaColaMx", "<Your Token>", 55, "id,name")
 
   See: https://developers.facebook.com/docs/graph-api/reference/page/feed
   """
-  def pageFeed(scope, page_id, access_token, limit \\ 25, fields \\ "") do
-    case scope do
-      :feed -> feed("feed", page_id, access_token, limit, fields)
-      :posts -> feed("posts", page_id, access_token, limit, fields)
-      :promotable -> feed("promotable_posts", page_id, access_token, limit, fields)
-      :tagged -> feed("tagged", page_id, access_token, limit, fields)
-      _ -> %{"error" => %{"message" => "Unknown type of feed"}}
-    end
-  end
-
-  """
-  Gets the feed of posts from Facebook.
-
-  See: https://developers.facebook.com/docs/graph-api/reference/page/feed
-  """
-  defp feed(scope, page_id, access_token, limit, fields) when limit <= 100 do
+  def pageFeed(scope, page_id, access_token, limit \\ 25, fields \\ "") when limit <= 100 do
     params = [access_token: access_token, limit: limit, fields: fields]
     if !is_nil(Config.appsecret) do
       params = params ++ [appsecret_proof: encrypt(access_token)]

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -285,7 +285,7 @@ defmodule Facebook do
   defp summaryCount(%{"total_count" => count}), do: count
 
   """
-  Returns a error if the summary requests failed.
+  Returns an error if the summary request fails.
   """
   defp summaryCount(%{"error" => error}), do: error
 


### PR DESCRIPTION
I have enhanced the pageFeed function.

Now you can pass the type of feed you want to get:

```
iex> Facebook.pageFeed(:posts, "CocaColaMx", "<Your Token>")
iex> Facebook.pageFeed(:tagged, "CocaColaMx", "<Your Token>", 55)
iex> Facebook.pageFeed(:promotable_posts, "CocaColaMx", "<Your Token>")
iex> Facebook.pageFeed(:feed, "CocaColaMx", "<Your Token>", 55, "id,name,actions")
```

All of this according to the [Graph API](https://developers.facebook.com/docs/graph-api/reference/v2.6/page/feed).