### PR TITLE
Fix getting the summary key, also added request to get the reactions count with single request

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -287,6 +287,7 @@ defmodule Facebook do
       iex> Facebook.objectCountAll("769860109692136_1173416799336463", "<Token>")
       %{"angry" => 0, "haha" => 1, "like" => 0, "love" => 0, "sad" => 0, "wow" => 0}
   """
+  @spec objectCountAll(object_id :: String.t, access_token) :: map
   def objectCountAll(object_id, access_token) do
     graph_query = """
     reactions.type(LIKE).summary(total_count).limit(0).as(like),

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -310,6 +310,7 @@ defmodule Facebook do
   defp getSummary(summary_response) do
     case summary_response do
       {:json, %{"error" => error}} -> %{"error" => error}
+      {:json, %{"summary" => summary}} -> summary
       {:json, info_map} -> info_map
     end
   end


### PR DESCRIPTION
Getting the object counts seems to be currently broken, the body returned from FB:

```
[info] body: "{\"data\":[],\"summary\":{\"total_count\":0,\"can_like\":true,\"has_liked\":false}}"
```

I added the additional "summary" key handling.
