### PR TITLE
Change logger level to debug

### DIFF
--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -56,13 +56,13 @@ defmodule Facebook.Graph do
   @spec request(method, url, payload, options) :: response
   defp request(method, url, payload, options) do
     headers = []
-    Logger.info fn ->
+    Logger.debug fn ->
       "[#{method}] #{url} #{inspect headers} #{inspect payload}"
     end
     case :hackney.request(method, url, headers, payload, options) do
       {:ok, _status_code, _headers, client_ref} ->
         {:ok, body} = :hackney.body(client_ref)
-        Logger.info fn ->
+        Logger.debug fn ->
           "body: #{inspect body}"
         end
         case JSON.decode(body) do


### PR DESCRIPTION
It's just a suggestion, but I think the logger info level is too high, specially if you use Phoenix and facebook.ex in the same application.