### PR TITLE
Capture hackney error

### DIFF
--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -68,7 +68,7 @@ defmodule Facebook.Graph do
 
     with {:ok, _status_code, _headers, client_ref} <- :hackney.request(method, url, headers, payload, options),
 	 {:ok, body} <- :hackney.body(client_ref) do
-      Logger.debug &("body: #{inspect body}")
+      Logger.debug fn -> "body: #{inspect body}" end
       case JSON.decode(body) do
         {:ok, data} ->
 	  {:json, data}
@@ -77,10 +77,10 @@ defmodule Facebook.Graph do
       end
     else
       {:error, reason} ->
-	Logger.error &("error: #{inspect reason}")
+	Logger.error fn -> "error: #{inspect reason}" end
         reason
       error ->
-        Logger.error &( "error: #{inspect error}" )
+        Logger.error fn -> "error: #{inspect error}"  end
         error
     end
   end

--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -65,22 +65,22 @@ defmodule Facebook.Graph do
     Logger.debug fn ->
       "[#{method}] #{url} #{inspect headers} #{inspect payload}"
     end
-    case :hackney.request(method, url, headers, payload, options) do
-      {:ok, _status_code, _headers, client_ref} ->
-        {:ok, body} = :hackney.body(client_ref)
-        Logger.debug fn ->
-          "body: #{inspect body}"
-        end
-        case JSON.decode(body) do
-          {:ok, data} ->
-            {:json, data}
-          _ ->
-            {:body, body}
-        end
+
+    with {:ok, _status_code, _headers, client_ref} <- :hackney.request(method, url, headers, payload, options),
+	 {:ok, body} <- :hackney.body(client_ref) do
+      Logger.debug &("body: #{inspect body}")
+      case JSON.decode(body) do
+        {:ok, data} ->
+	  {:json, data}
+        _ ->
+	  {:body, body}
+      end
+    else
+      {:error, reason} ->
+	Logger.error &("error: #{inspect reason}")
+        reason
       error ->
-        Logger.error fn ->
-          "error: #{inspect error}"
-        end
+        Logger.error &( "error: #{inspect error}" )
         error
     end
   end

--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -67,17 +67,15 @@ defmodule Facebook.Graph do
     end
 
     with {:ok, _status_code, _headers, client_ref} <- :hackney.request(method, url, headers, payload, options),
-	 {:ok, body} <- :hackney.body(client_ref) do
+	       {:ok, body} <- :hackney.body(client_ref) do
       Logger.debug fn -> "body: #{inspect body}" end
       case JSON.decode(body) do
-        {:ok, data} ->
-	  {:json, data}
-        _ ->
-	  {:body, body}
+        {:ok, data} -> {:json, data}
+        _           -> {:body, body}
       end
     else
       {:error, reason} ->
-	Logger.error fn -> "error: #{inspect reason}" end
+        Logger.error fn -> "error: #{inspect reason}" end
         reason
       error ->
         Logger.error fn -> "error: #{inspect error}"  end


### PR DESCRIPTION
`:hackney.body(client_ref)` can return `{:ok, body}` or `{:error, reason}`, so I edited the code a little in order to manage both cases.