### PR TITLE
Bump Facebook API version to 2.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Facebook.Mixfile do
       applications: [:json, :hackney, :logger],
       env: [
         env: :dev,
-        graph_url: "https://graph.facebook.com/v2.6",
+        graph_url: "https://graph.facebook.com/v2.9",
         appsecret: nil
       ]
     ]


### PR DESCRIPTION
This commit bumps the graph_url to v2.9, the current API version.