### PR TITLE
Add publish to feed

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -76,6 +76,33 @@ defmodule Facebook do
   end
 
   @doc """
+  Publish to a feed. Author (user or page) is determined from the supplied token.
+
+  The `feed_id` is the id for the user or page feed to publish to.
+  Apps need both `manage_pages` and `publish_pages` to be able to publish as a Page.
+  The `publish_actions` permission is required to publish as an individual.
+
+  See Facebook's publishing documentation for more info:
+
+  * https://developers.facebook.com/docs/pages/publishing
+  * https://developers.facebook.com/docs/pages/publishing#personal_post
+  * https://developers.facebook.com/docs/facebook-login/permissions#reference-publish_pages
+
+  ## Examples
+      iex> # publish a message
+      iex> Facebook.publish(:feed, "<Feed Id>", [message: "<Message Body"], "<Acess Token>")
+
+      iex> # publish a link and message
+      iex> Facebook.publish(:feed, "<Feed Id>", [message: "<Message Body", link: "www.example.com"], "<Access Token>")
+
+  """
+  @spec publish(:feed, feed_id :: String.t, fields, access_token) :: response
+  def publish(:feed, feed_id, fields, access_token) do
+    params = fields ++ [access_token: access_token]
+    Facebook.Graph.post("/#{feed_id}/feed", params, [])
+  end
+
+  @doc """
   A Picture for a Facebook User
 
   ## Example

--- a/lib/facebook/graph.ex
+++ b/lib/facebook/graph.ex
@@ -49,6 +49,15 @@ defmodule Facebook.Graph do
   end
 
   @doc """
+  HTTP POST using path, params and options
+  """
+  @spec post(path, params, options) :: response
+  def post(path, params, options) do
+    url = :hackney_url.make_url(Config.graph_url, path, params)
+    request(:post, url, options)
+  end
+
+  @doc """
   HTTP generic request (GET, POST, etc) using a full URL and options
   """
   @spec request(method, url, options) :: response

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -46,6 +46,13 @@ defmodule FacebookTest do
     assert(String.length(pictureData["data"]["url"]) > 0)
   end
 
+  test "publish", context do
+    %{id: id, access_token: access_token} = context
+
+    {:json, response} = Facebook.publish(:feed, id, [message: "test message", link: "www.example.org"], access_token)
+    assert(String.length(response["id"]) > 0)
+  end
+
   test "myLikes", context do
     %{access_token: access_token} = context
 


### PR DESCRIPTION
Didn't see any publishing functionality provided by the main `Facebook` module so figured I'd share this.

Coverage for most use cases is pretty good provided you know which fields to pass, adding a few more examples may help increase awareness to whats available (scheduling post datetime, setting post as unpublished are some examples), for now the facebook documentation is referenced in the doc.