### PR TITLE
In-app payment methods

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -285,8 +285,8 @@ defmodule Facebook do
   @spec picture(page_id, type :: String.t, access_token) :: resp
   def picture(page_id, type, access_token) do
     params = [type: type, redirect: false]
-               |> add_access_token(access_token)
                |> add_app_secret(access_token)
+               |> add_access_token(access_token)
 
     ~s(/#{page_id}/picture)
       |> GraphAPI.get([], params: params)
@@ -780,7 +780,7 @@ defmodule Facebook do
   # Hashes the token together with the app secret according to the
   # guidelines of facebook to build an unencoded/raw signature.
   defp signature(str) do
-    :sha256 |> :crypto.hmac(Config.app_secret, str)
+    :crypto.hmac(:sha256, Config.app_secret(), str)
   end
 
   # Uses signature/1 to build a urlsafe base64-encoded signature
@@ -796,7 +796,7 @@ defmodule Facebook do
   # Add the appsecret_proof to the GraphAPI request params if the app secret is
   # defined
   defp add_app_secret(params, access_token) do
-    if is_nil(Config.app_secret) do
+    if is_nil(Config.app_secret()) do
       params
     else
       params ++ [appsecret_proof: signature_base16(access_token)]

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -104,18 +104,18 @@ defmodule Facebook do
   """
   @type scope :: atom | String.t
 
-  @type using_appsecret :: boolean
+  @type using_app_secret :: boolean
 
   @doc """
-  If you want to use an appsecret proof, pass it into set_appsecret:
+  If you want to use an appsecret proof, pass it into set_app_secret:
 
   ## Example
-      iex> Facebook.set_appsecret("appsecret")
+      iex> Facebook.set_app_secret("app_secret")
 
   See: https://developers.facebook.com/docs/graph-api/securing-requests
   """
-  def set_appsecret(appsecret) do
-    Config.appsecret(appsecret)
+  def set_app_secret(app_secret) do
+    Config.app_secret(app_secret)
   end
 
   @doc """
@@ -660,14 +660,14 @@ defmodule Facebook do
   # guidelines of facebook.
   defp encrypt(token) do
     :sha256
-      |> :crypto.hmac(Config.appsecret, token)
+      |> :crypto.hmac(Config.app_secret, token)
       |> Base.encode16(case: :lower)
   end
 
   # Add the appsecret_proof to the GraphAPI request params if the app secret is
   # defined
   defp add_app_secret(params, access_token) do
-    if is_nil(Config.appsecret) do
+    if is_nil(Config.app_secret) do
       params
     else
       params ++ [appsecret_proof: encrypt(access_token)]

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -494,6 +494,23 @@ defmodule Facebook do
   end
 
   @doc """
+  Gets payment info about a single payment.
+
+  ## Examples
+      iex> Facebook.payment("769860109692136", "<App Access Token>", "id,request_id,actions")
+      {:ok, %{"request_id" => "abc2387238", "id" => "116397053038597", "actions" => [ %{ "type" => "charge", ... } ] } }
+  """
+  @spec payment(object_id, access_token, fields) :: resp
+  def payment(payment_id, access_token, fields \\ "") do
+    params = [fields: fields]
+               |> add_access_token(access_token)
+
+    ~s(/#{payment_id})
+      |> GraphAPI.get([], params: params)
+      |> ResponseFormatter.format_response
+  end
+
+  @doc """
   Exchange an authorization code for an access token.
 
   If you are implementing user authentication, the `code` is generated from a Facebook

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -104,6 +104,16 @@ defmodule Facebook do
   """
   @type scope :: atom | String.t
 
+  @typedoc """
+  A reason for settling a payment dispute.
+
+  Reasons:
+    * `:GRANTED_REPLACEMENT_ITEM`
+    * `:DENIED_REFUND`
+    * `:BANNED_USER`
+  """
+  @type dispute_reason :: atom | String.t
+
   @type using_app_secret :: boolean
 
   @doc """
@@ -511,6 +521,26 @@ defmodule Facebook do
     ~s(/#{payment_id})
       |> GraphAPI.get([], params: params)
       |> ResponseFormatter.format_response
+  end
+
+  @doc """
+  Settle a payment dispute.
+
+  ## Examples
+      iex> Facebook.dispute("769860109692136", "<App Access Token>", :DENIED_REFUND)
+      {:ok, %{"success" => true}}
+
+  See:
+    * https://developers.facebook.com/docs/graph-api/reference/payment/dispute
+  """
+  @spec dispute(object_id, access_token, dispute_reason) :: resp
+  def dispute(payment_id, access_token, reason) do
+    params = []
+               |> add_access_token(access_token)
+
+    ~s(/#{payment_id}/dispute)
+    |> GraphAPI.post("reason=#{reason}", params: params)
+    |> ResponseFormatter.format_response
   end
 
   @doc """

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -567,11 +567,16 @@ defmodule Facebook do
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment/refunds
   """
+  # credo:disable-for-lines:1 Credo.Check.Readability.MaxLineLength
   @spec refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
   def refunds(payment_id, access_token, currency, amount, reason) do
     params = []
                |> add_access_token(access_token)
-    body = URI.encode_query(%{currency: currency, amount: amount, reason: reason})
+    body = URI.encode_query(%{
+      currency: currency,
+      amount: amount,
+      reason: reason
+    })
 
     ~s(/#{payment_id}/refunds)
       |> GraphAPI.post(body, params: params)

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -114,6 +114,19 @@ defmodule Facebook do
   """
   @type dispute_reason :: atom | String.t
 
+  @typedoc """
+  A reason for refunding a payment.
+
+  Reasons:
+    * `:MALICIOUS_FRAUD`
+    * `:FRIENDLY_FRAUD`
+    * `:CUSTOMER_SERVICE`
+  """
+  @type refunds_reason :: atom | String.t
+
+  @type currency :: String.t
+  @type amount :: Number.t
+
   @type using_app_secret :: boolean
 
   @doc """
@@ -541,6 +554,26 @@ defmodule Facebook do
     ~s(/#{payment_id}/dispute)
     |> GraphAPI.post("reason=#{reason}", params: params)
     |> ResponseFormatter.format_response
+
+  @doc """
+  Refund a payment.
+
+  ## Examples
+      iex> Facebook.refunds("769860109692136", "<App Access Token>", "EUR", 10.99, :CUSTOMER_SERVICE)
+      {:ok, %{"success" => true}}
+
+  See:
+    * https://developers.facebook.com/docs/graph-api/reference/payment/refunds
+  """
+  @spec refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
+  def refunds(payment_id, access_token, currency, amount, reason) do
+    params = []
+               |> add_access_token(access_token)
+    body = URI.encode_query(%{currency: currency, amount: amount, reason: reason})
+
+    ~s(/#{payment_id}/refunds)
+      |> GraphAPI.post(body, params: params)
+      |> ResponseFormatter.format_response
   end
 
   @doc """

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -550,10 +550,12 @@ defmodule Facebook do
   def dispute(payment_id, access_token, reason) do
     params = []
                |> add_access_token(access_token)
+    body = URI.encode_query(%{reason: reason})
 
     ~s(/#{payment_id}/dispute)
-    |> GraphAPI.post("reason=#{reason}", params: params)
-    |> ResponseFormatter.format_response
+      |> GraphAPI.post(body, params: params)
+      |> ResponseFormatter.format_response
+  end
 
   @doc """
   Refund a payment.

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -499,6 +499,9 @@ defmodule Facebook do
   ## Examples
       iex> Facebook.payment("769860109692136", "<App Access Token>", "id,request_id,actions")
       {:ok, %{"request_id" => "abc2387238", "id" => "116397053038597", "actions" => [ %{ "type" => "charge", ... } ] } }
+
+  See:
+    * https://developers.facebook.com/docs/graph-api/reference/payment
   """
   @spec payment(object_id, access_token, fields) :: resp
   def payment(payment_id, access_token, fields \\ "") do

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -546,14 +546,14 @@ defmodule Facebook do
   Settle a payment dispute.
 
   ## Examples
-      iex> Facebook.dispute("769860109692136", "<App Access Token>", :DENIED_REFUND)
+      iex> Facebook.payment_dispute("769860109692136", "<App Access Token>", :DENIED_REFUND)
       {:ok, %{"success" => true}}
 
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment/dispute
   """
-  @spec dispute(object_id, access_token, dispute_reason) :: resp
-  def dispute(payment_id, access_token, reason) do
+  @spec payment_dispute(object_id, access_token, dispute_reason) :: resp
+  def payment_dispute(payment_id, access_token, reason) do
     params = []
                |> add_access_token(access_token)
     body = URI.encode_query(%{reason: reason})
@@ -567,15 +567,15 @@ defmodule Facebook do
   Refund a payment.
 
   ## Examples
-      iex> Facebook.refunds("769860109692136", "<App Access Token>", "EUR", 10.99, :CUSTOMER_SERVICE)
+      iex> Facebook.payment_refunds("769860109692136", "<App Access Token>", "EUR", 10.99, :CUSTOMER_SERVICE)
       {:ok, %{"success" => true}}
 
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment/refunds
   """
   # credo:disable-for-lines:1 Credo.Check.Readability.MaxLineLength
-  @spec refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
-  def refunds(payment_id, access_token, currency, amount, reason) do
+  @spec payment_refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
+  def payment_refunds(payment_id, access_token, currency, amount, reason) do
     params = []
                |> add_access_token(access_token)
     body = URI.encode_query(%{
@@ -714,12 +714,11 @@ defmodule Facebook do
 
   @doc """
   Decodes a signed request from a client SDK (in-app payments), verifies the
-  signature and -if valid- returns its contents.
+  signature and (if it is valid) returns its decoded contents.
   """
   @spec decode_signed_request(signed_request) :: resp
   def decode_signed_request(signed_request) when is_binary(signed_request) do
-    with [signature_str | [payload_str | _]] when
-           is_binary(signature_str) and is_binary(payload_str)
+    with [signature_str | [payload_str | _]]
            <- String.split(signed_request, "."),
          {:ok, signature} <- Base.url_decode64(signature_str),
          _signature_verification = ^signature <- signature(payload_str),

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -12,12 +12,34 @@ defmodule Facebook.Config do
     Application.fetch_env! :facebook, :graph_video_url
   end
 
-  # App secret
+  # App secret a.k.a. client secret
   def appsecret do
-    Application.fetch_env! :facebook, :appsecret
+    IO.warn("'appsecret' method is deprecated. Please use 'app_secret'", Macro.Env.stacktrace(__ENV__))
+    app_secret()
+  end
+  def app_secret do
+    with :error <- Application.fetch_env(:facebook, :appsecret)
+    do
+      Application.fetch_env!(:facebook, :app_secret)
+    else
+      {:ok, secret} ->
+        IO.warn("'appsecret' configuration value is deprecated. Please use 'app_secret'", Macro.Env.stacktrace(__ENV__))
+        secret
+    end
   end
 
   def appsecret(appsecret) do
-    Application.put_env :facebook, :appsecret, appsecret
+    IO.warn("'appsecret' method value is deprecated. Please use 'app_secret'", Macro.Env.stacktrace(__ENV__))
+    app_secret(appsecret)
+  end
+  def app_secret(app_secret) do
+    case Application.fetch_env(:facebook, :appsecret) do
+      {:ok, _} ->
+        IO.warn("'appsecret' configuration value is deprecated. Please use 'app_secret'", Macro.Env.stacktrace(__ENV__))
+        Application.put_env :facebook, :appsecret, app_secret
+      _ ->
+        Application.put_env :facebook, :app_secret, app_secret
+    end
+  end
   end
 end

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -49,6 +49,6 @@ defmodule Facebook.Config do
 
   # App access token
   def app_access_token do
-    "#{app_id()}|#{app_secret()}"
+    Application.fetch_env! :facebook, :app_access_token
   end
 end

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -41,5 +41,14 @@ defmodule Facebook.Config do
         Application.put_env :facebook, :app_secret, app_secret
     end
   end
+
+  # App id, a.k.a. client id
+  def app_id do
+    Application.fetch_env! :facebook, :app_id
+  end
+
+  # App access token
+  def app_access_token do
+    "#{app_id()}|#{app_secret()}"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Facebook.Mixfile do
         env: :dev,
         graph_url: "https://graph.facebook.com/v2.9",
         graph_video_url: "https://graph-video.facebook.com/v2.9",
-        app_secret: nil
+        app_secret: nil,
+        app_id: nil
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Facebook.Mixfile do
         env: :dev,
         graph_url: "https://graph.facebook.com/v2.9",
         graph_video_url: "https://graph-video.facebook.com/v2.9",
-        appsecret: nil
+        app_secret: nil
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Facebook.Mixfile do
         graph_url: "https://graph.facebook.com/v2.9",
         graph_video_url: "https://graph-video.facebook.com/v2.9",
         app_secret: nil,
-        app_id: nil
+        app_id: nil,
+        app_access_token: nil
       ]
     ]
   end

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -391,7 +391,7 @@ defmodule FacebookTest do
     end
   end
 
-  describe "payment dispute" do
+  describe "dispute" do
     test "success", %{app_access_token: app_access_token} do
       with_mock :hackney, GraphMock.mock_options(
         fn(_) -> GraphMock.dispute(:success) end

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -364,6 +364,19 @@ defmodule FacebookTest do
     end
   end
 
+  describe "payment" do
+    test "success", %{app_access_token: app_access_token} do
+      with_mock :hackney, GraphMock.mock_options(
+        fn(_) -> GraphMock.payment(:success, :no_fields) end
+      ) do
+        assert {:ok, %{"id" => "#{@payment_id}", "created_time" => "2018-01-28T00:33:19+0000"}} = Facebook.payment(
+          @payment_id,
+          app_access_token
+        )
+      end
+    end
+  end
+
   describe "payment with fields" do
     test "success", %{app_access_token: app_access_token} do
       with_mock :hackney, GraphMock.mock_options(

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -391,6 +391,21 @@ defmodule FacebookTest do
     end
   end
 
+  describe "payment dispute" do
+    test "success", %{app_access_token: app_access_token} do
+      with_mock :hackney, GraphMock.mock_options(
+        fn(_) -> GraphMock.dispute(:success) end
+      ) do
+        assert {:ok, %{"success" => true}} = Facebook.dispute(
+          @payment_id,
+          app_access_token,
+          :REFUND_DENIED
+        )
+      end
+    end
+  end
+
+
   describe "long lived access token" do
     test "success", %{access_token: access_token} do
       with_mock :hackney, GraphMock.mock_options(

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -405,6 +405,21 @@ defmodule FacebookTest do
     end
   end
 
+  describe "refunds" do
+    test "success", %{app_access_token: app_access_token} do
+      with_mock :hackney, GraphMock.mock_options(
+        fn(_) -> GraphMock.refunds(:success) end
+                ) do
+        assert {:ok, %{"success" => true}} = Facebook.refunds(
+          @payment_id,
+          app_access_token,
+          "EUR",
+          10.99,
+          :CUSTOMER_SERVICE
+        )
+      end
+    end
+  end
 
   describe "long lived access token" do
     test "success", %{access_token: access_token} do

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -19,6 +19,7 @@ defmodule FacebookTest do
   @app_secret "456"
   @page_id 19292868552          # This is the facebook for developers page id
   @test_page_id 629965917187496 # `page_id` the test user created
+  @payment_id "11639730386596"
 
   setup do
     [
@@ -359,6 +360,20 @@ defmodule FacebookTest do
 
         assert haha == 135
         assert love == 10
+      end
+    end
+  end
+
+  describe "payment with fields" do
+    test "success", %{app_access_token: app_access_token} do
+      with_mock :hackney, GraphMock.mock_options(
+        fn(_) -> GraphMock.payment(:success, :with_fields) end
+      ) do
+        assert {:ok, %{"request_id" => "A76449","id" => "#{@payment_id}", "actions" => [ %{} ]}} = Facebook.payment(
+          @payment_id,
+          app_access_token,
+          "id,request_id,actions,payout_foreign_exchange_rate"
+        )
       end
     end
   end

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -391,12 +391,12 @@ defmodule FacebookTest do
     end
   end
 
-  describe "dispute" do
+  describe "payment dispute" do
     test "success", %{app_access_token: app_access_token} do
       with_mock :hackney, GraphMock.mock_options(
         fn(_) -> GraphMock.dispute(:success) end
       ) do
-        assert {:ok, %{"success" => true}} = Facebook.dispute(
+        assert {:ok, %{"success" => true}} = Facebook.payment_dispute(
           @payment_id,
           app_access_token,
           :REFUND_DENIED
@@ -405,12 +405,12 @@ defmodule FacebookTest do
     end
   end
 
-  describe "refunds" do
+  describe "payment refunds" do
     test "success", %{app_access_token: app_access_token} do
       with_mock :hackney, GraphMock.mock_options(
         fn(_) -> GraphMock.refunds(:success) end
                 ) do
-        assert {:ok, %{"success" => true}} = Facebook.refunds(
+        assert {:ok, %{"success" => true}} = Facebook.payment_refunds(
           @payment_id,
           app_access_token,
           "EUR",

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -421,6 +421,22 @@ defmodule FacebookTest do
     end
   end
 
+  describe "signing" do
+    Facebook.set_app_secret(@app_secret)
+
+    test "payload" do
+      payload = JSON.encode!(%{id: @payment_id})
+      assert "EdOhTfnZaIM3-Ht7X_4vgEQnIRq9fpzRgONlMvwRGKI=.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0=" = Facebook.sign(payload)
+    end
+
+    test "decode" do
+      signed_request = "EdOhTfnZaIM3-Ht7X_4vgEQnIRq9fpzRgONlMvwRGKI=.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0="
+      assert {:ok, %{
+        "id" => @payment_id
+      }} = Facebook.decode_signed_request(signed_request)
+    end
+  end
+
   describe "long lived access token" do
     test "success", %{access_token: access_token} do
       with_mock :hackney, GraphMock.mock_options(

--- a/test/graph_mock.ex
+++ b/test/graph_mock.ex
@@ -128,6 +128,12 @@ defmodule Facebook.GraphMock do
     })
   end
 
+  def dispute(:success) do
+    JSON.encode(%{
+      "success": true
+    })
+  end
+
   def mock_options(body_function) do
     [
       request: request(),

--- a/test/graph_mock.ex
+++ b/test/graph_mock.ex
@@ -102,6 +102,13 @@ defmodule Facebook.GraphMock do
     })
   end
 
+  def payment(:success, :no_fields) do
+    JSON.encode(%{
+      "id": "11639730386596",
+      "created_time": "2018-01-28T00:33:19+0000",
+    })
+  end
+
   def payment(:success, :with_fields) do
     JSON.encode(%{
       "request_id": "A76449",

--- a/test/graph_mock.ex
+++ b/test/graph_mock.ex
@@ -134,6 +134,12 @@ defmodule Facebook.GraphMock do
     })
   end
 
+  def refunds(:success) do
+    JSON.encode(%{
+      "success": true
+    })
+  end
+
   def mock_options(body_function) do
     [
       request: request(),

--- a/test/graph_mock.ex
+++ b/test/graph_mock.ex
@@ -102,6 +102,25 @@ defmodule Facebook.GraphMock do
     })
   end
 
+  def payment(:success, :with_fields) do
+    JSON.encode(%{
+      "request_id": "A76449",
+      "id": "11639730386596",
+      "actions": [
+        %{
+          "type": "charge",
+          "status": "completed",
+          "currency": "EUR",
+          "amount": "11.99",
+          "time_created": "2018-01-28T00:33:19+0000",
+          "time_updated": "2018-01-28T00:33:20+0000",
+          "tax_amount": "2.08"
+        }
+      ],
+      "payout_foreign_exchange_rate": 1.2308349
+    })
+  end
+
   def mock_options(body_function) do
     [
       request: request(),


### PR DESCRIPTION
Consists of two parts to support in-app payment calls:
1. renamed config option `appsecret` to `app_secret` and added `app_id`config option to be able to supply `app_access_token()` method (with deprecation warnings)
2. added `payment`, `dispute` and `refunds` calls