### PR TITLE
App access token handling

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -544,61 +544,63 @@ defmodule Facebook do
   end
 
   @doc """
-  Gets payment info about a single payment.
+  Gets payment info about a single payment. Needs the app access token from the configuration.
 
   ## Examples
-      iex> Facebook.payment("769860109692136", "<App Access Token>", "id,request_id,actions")
+      iex> Facebook.payment("769860109692136", "id,request_id,actions")
       {:ok, %{"request_id" => "abc2387238", "id" => "116397053038597", "actions" => [ %{ "type" => "charge", ... } ] } }
 
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment
   """
-  @spec payment(object_id, access_token, fields) :: resp
-  def payment(payment_id, access_token, fields \\ "") do
+  @spec payment(object_id, fields) :: resp
+  def payment(payment_id, fields \\ "") do
     params = [fields: fields]
-               |> add_access_token(access_token)
+               |> add_app_access_token()
 
     ~s(/#{payment_id})
       |> GraphAPI.get([], params: params)
       |> ResponseFormatter.format_response
   end
+  @spec payment(object_id, access_token, fields) :: resp
+  def payment(_payment_id, _access_token, _fields \\ ""), do: raise "this method is deprecated, please configure app_access_token and use payment/2"
 
   @doc """
-  Settle a payment dispute.
+  Settle a payment dispute. Needs the app access token from the configuration.
 
   ## Examples
-      iex> Facebook.payment_dispute("769860109692136", "<App Access Token>", :DENIED_REFUND)
+      iex> Facebook.payment_dispute("769860109692136", :DENIED_REFUND)
       {:ok, %{"success" => true}}
 
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment/dispute
   """
-  @spec payment_dispute(object_id, access_token, dispute_reason) :: resp
-  def payment_dispute(payment_id, access_token, reason) do
-    params = []
-               |> add_access_token(access_token)
+  @spec payment_dispute(object_id, dispute_reason) :: resp
+  def payment_dispute(payment_id, reason) do
+    params = add_app_access_token([])
     body = URI.encode_query(%{reason: reason})
 
     ~s(/#{payment_id}/dispute)
       |> GraphAPI.post(body, params: params)
       |> ResponseFormatter.format_response
   end
+  @spec payment(object_id, access_token, dispute_reason) :: resp
+  def payment_dispute(_payment_id, _access_token, _reason), do: raise "this method is deprecated, please configure app_access_token and use payment_dispute/2"
 
   @doc """
-  Refund a payment.
+  Refund a payment. Needs the app access token from the configuration.
 
   ## Examples
-      iex> Facebook.payment_refunds("769860109692136", "<App Access Token>", "EUR", 10.99, :CUSTOMER_SERVICE)
+      iex> Facebook.payment_refunds("769860109692136", "EUR", 10.99, :CUSTOMER_SERVICE)
       {:ok, %{"success" => true}}
 
   See:
     * https://developers.facebook.com/docs/graph-api/reference/payment/refunds
   """
   # credo:disable-for-lines:1 Credo.Check.Readability.MaxLineLength
-  @spec payment_refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
-  def payment_refunds(payment_id, access_token, currency, amount, reason) do
-    params = []
-               |> add_access_token(access_token)
+  @spec payment_refunds(object_id, currency, amount, refunds_reason) :: resp
+  def payment_refunds(payment_id, currency, amount, reason) do
+    params = add_app_access_token([])
     body = URI.encode_query(%{
       currency: currency,
       amount: amount,
@@ -609,6 +611,9 @@ defmodule Facebook do
       |> GraphAPI.post(body, params: params)
       |> ResponseFormatter.format_response
   end
+  # credo:disable-for-lines:1 Credo.Check.Readability.MaxLineLength
+  @spec payment_refunds(object_id, access_token, currency, amount, refunds_reason) :: resp
+  def payment_refunds(_payment_id, _access_token, _currency, _amount, _reason), do: raise "this method is deprecated, please configure app_access_token and use payment_refunds/4"
 
   @doc """
   Exchange an authorization code for an access token.
@@ -664,15 +669,14 @@ defmodule Facebook do
   end
 
   @doc """
-  Get all test users for an app.
+  Get all test users for an app. Needs the app access token from the configuration.
 
-  The access token in this case needs to be an app access token.
   See:
     - https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens
     - https://developers.facebook.com/docs/graph-api/reference/v2.8/app/accounts/test-users
 
   ## Examples
-      iex> Facebook.test_users("appId", "appId|appSecret")
+      iex> Facebook.test_users("appId")
       {:ok, %{"data" => [
         %{
           "access_token" => "ACCESS_TOKEN",
@@ -681,10 +685,9 @@ defmodule Facebook do
         }
       ]}
   """
-  @spec test_users(client_id, access_token) :: resp
-  def test_users(client_id, access_token) do
-    params = []
-               |> add_access_token(access_token)
+  @spec test_users(client_id) :: resp
+  def test_users(client_id) do
+    params = add_app_access_token([])
     ~s(/#{client_id}/accounts/test-users)
       |> GraphAPI.get([], params: params)
       |> ResponseFormatter.format_response
@@ -701,6 +704,7 @@ defmodule Facebook do
 
   An app access token or an app developer's user access token for the
   app associated with the input_token is required to access.
+  debug_token/1 can be used if an app_access_token was configured and should be used.
 
   See:
    - https://developers.facebook.com/docs/graph-api/reference/v2.11/debug_token
@@ -731,6 +735,17 @@ defmodule Facebook do
     ~s(/debug_token)
     |> GraphAPI.get([], params: params)
     |> ResponseFormatter.format_response()
+  end
+
+  @doc """
+  Calls debug_token/2 with the previously configured app_access_token.
+
+  See:
+   - debug_token/2
+  """
+  @spec debug_token(access_token) :: resp
+  def debug_token(input_token) do
+    debug_token(input_token, Config.app_access_token())
   end
 
   @doc """
@@ -827,5 +842,9 @@ defmodule Facebook do
   ## Add access_token to params
   defp add_access_token(fields, token) do
     fields ++ [access_token: token]
+  end
+
+  defp add_app_access_token(fields) do
+    fields ++ [access_token: Config.app_access_token()]
   end
 end

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -136,7 +136,8 @@ defmodule Facebook do
   @type using_app_secret :: boolean
 
   @doc """
-  If you want to use an appsecret proof, pass it into set_app_secret:
+  Sets the app secret at runtime to make the calls send an appsecret proof with every request to the Graph API.
+  Note: the app secret may also be set in the configuration.
 
   ## Example
       iex> Facebook.set_app_secret("app_secret")
@@ -699,7 +700,7 @@ defmodule Facebook do
   This may be used to programatically debug issues with large sets of access tokens.
 
   An app access token or an app developer's user access token for the
-  app associated with the input_token is required to acces.
+  app associated with the input_token is required to access.
 
   See:
    - https://developers.facebook.com/docs/graph-api/reference/v2.11/debug_token

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -3,11 +3,12 @@ defmodule Facebook.Config do
   Config helpers
   """
 
-  # URL to the Facebook Graph including the version.
+  # URL to the Facebook Graph including the version (no slash at the end!)
   def graph_url do
     Application.fetch_env! :facebook, :graph_url
   end
 
+  # URL to the Facebook Graph for video including the version (no slash at the end!)
   def graph_video_url do
     Application.fetch_env! :facebook, :graph_video_url
   end
@@ -20,7 +21,7 @@ defmodule Facebook.Config do
   def app_secret do
     with :error <- Application.fetch_env(:facebook, :appsecret)
     do
-      Application.fetch_env!(:facebook, :app_secret)
+      Application.fetch_env! :facebook, :app_secret
     else
       {:ok, secret} ->
         IO.warn("'appsecret' configuration value is deprecated. Please use 'app_secret'", Macro.Env.stacktrace(__ENV__))

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -52,4 +52,8 @@ defmodule Facebook.Config do
   def app_access_token do
     Application.fetch_env! :facebook, :app_access_token
   end
+
+  def app_access_token(app_access_token) do
+    Application.put_env :facebook, :app_access_token, app_access_token
+  end
 end


### PR DESCRIPTION
For calls **requiring** an _app access token_, use the configured `app_access_token` instead of taking an access token as input parameter. Deprecates the old version of these calls!

@mweibel What I did _not_ do is wrap the app access token setter from Facebook.Config into Facebook (set_app_secret) because I couldn't think of a scenario where this would be needed... maybe you can help me with that? In which cases do you use `Facebook.set_app_secret/1` or even `Facebook.Config.app_secret/1`?