### PR TITLE
NEW: optionally configure connection timeouts

### DIFF
--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -51,4 +51,14 @@ defmodule Facebook.Config do
   def app_access_token do
     Application.fetch_env! :facebook, :app_access_token
   end
+
+  # Request conn_timeout
+  def request_conn_timeout do
+    Application.fetch_env(:facebook, :request_conn_timeout)
+  end
+
+  # Request recv_timeout
+  def request_recv_timeout do
+    Application.fetch_env(:facebook, :request_recv_timeout)
+  end
 end

--- a/lib/facebook/graph_api.ex
+++ b/lib/facebook/graph_api.ex
@@ -5,6 +5,18 @@ defmodule Facebook.GraphAPI do
 
   alias Facebook.Config
 
+  def process_request_options(options) do
+    updated_options = case Config.request_conn_timeout do
+      :error -> options
+      val -> options ++ [timeout: val]
+    end
+
+    case Config.request_recv_timeout do
+      :error -> updated_options
+      val -> updated_options ++ [recv_timeout: val]
+    end
+  end
+
   def process_url(url), do: Config.graph_url <> url
 
   def process_response_body(body) do


### PR DESCRIPTION
Optionally configure connection and receive timeout for network requests via two new config options: `request_conn_timeout` and `request_recv_timeout`.