### PR TITLE
Use the exact url in the pagination response

### DIFF
--- a/lib/facebook/graph_api.ex
+++ b/lib/facebook/graph_api.ex
@@ -18,7 +18,7 @@ defmodule Facebook.GraphAPI do
     end
   end
 
-  def process_url("https://graph.facebook.com/" <> _ = url), do: url
+  def process_url("https://" <> _ = url), do: url
 
   def process_url(url), do: Config.graph_url() <> url
 

--- a/lib/facebook/graph_api.ex
+++ b/lib/facebook/graph_api.ex
@@ -17,6 +17,8 @@ defmodule Facebook.GraphAPI do
     end
   end
 
+  def process_url("https://graph.facebook.com/" <> _ = url), do: url
+
   def process_url(url), do: Config.graph_url <> url
 
   def process_response_body(body) do

--- a/lib/facebook/graph_api.ex
+++ b/lib/facebook/graph_api.ex
@@ -6,12 +6,13 @@ defmodule Facebook.GraphAPI do
   alias Facebook.Config
 
   def process_request_options(options) do
-    updated_options = case Config.request_conn_timeout do
-      :error -> options
-      val -> options ++ [timeout: val]
-    end
+    updated_options =
+      case Config.request_conn_timeout() do
+        :error -> options
+        val -> options ++ [timeout: val]
+      end
 
-    case Config.request_recv_timeout do
+    case Config.request_recv_timeout() do
       :error -> updated_options
       val -> updated_options ++ [recv_timeout: val]
     end
@@ -19,10 +20,10 @@ defmodule Facebook.GraphAPI do
 
   def process_url("https://graph.facebook.com/" <> _ = url), do: url
 
-  def process_url(url), do: Config.graph_url <> url
+  def process_url(url), do: Config.graph_url() <> url
 
   def process_response_body(body) do
     body
-      |> JSON.decode
+    |> JSON.decode()
   end
 end


### PR DESCRIPTION
Hi, 

I was playing around with fetching all available data from Facebook using Facebook.Stream.new, and came across this issue. I found it was failing with HTTPoison's `:nxdomain` error, and found `Facebook.Stream` wasing using `Facebook.GraphAPI`, which has  this function:

```
def process_url(url), do: Config.graph_url <> url
```

It attaches the graph endpoint url for all outgoing calls.
This wouldn't work for stream since the next page already comes with complete url:

```
https://graph.facebook.com/v3.1/260154614531202/live_videos?access_token=<access_token>&limit=25&after=QVFIUl9Bbnd2aTdSZAUhOWGp6ZA1ZA6aER3dk52ZATBCcGdILXlrUTIxenpQWGpuUFE5NnJDZAWVUYjZA3XzAxT1hZAdmlId1dhb0JTZAERqWWNrTnNqRjdKWGhsOTdR
```
 
This PR opts in to match if url contains protocol, if it does, use the url as is.

It fixes the issue for Facebook.Stream