### PR TITLE
Add support for runtime configuration via {:system, _} tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,46 @@ $ mix deps.get
 ## Configuration
 
 You can configure facebook.ex in your mix `config.exs` (or, if you're using the Phoenix Framework, in your `config/dev.exs|test.exs|prod.exs`, respectively) with the following keys, which state the library defaults:
+
 ```
 config :facebook,
   app_id: nil,
   app_secret: nil,
   app_access_token: nil,
   graph_url: "https://graph.facebook.com",
-  graph_video_url: "https://graph-video.facebook.com"
+  graph_video_url: "https://graph-video.facebook.com",
+  request_conn_timeout: nil,
+  request_recv_timeout: nil
 ```
-For graph_url and video_graph_url, Facebook automatically uses the oldest active Graph API version available if you don't specify a version in the url. You may use versioned urls to pin your calls to a specific API versions (recommended), e.g. like so:
+
+For `graph_url` and `video_graph_url`, Facebook automatically uses the oldest active Graph API version available if you don't specify a version in the url. You may use versioned urls to pin your calls to a specific API versions (recommended), e.g. like so:
+
 ```
   graph_url: "https://graph.facebook.com/v2.11",
   graph_video_url: "https://graph-video.facebook.com/v2.8"
 ```
+
 Note that you *must not* end the urls with a slash or the requests will fail (Facebook will report an error about unknown url components)!
 
 `app_id`, `app_secret` and `app_access_token` do not need to be supplied if you are using no Graph API calls that require them (e.g. payment calls).
-If you supply the `app_secret`, an [appsecret_proof](https://developers.facebook.com/docs/graph-api/securing-requests) will be submitted along with the Graph API requests. The app_secret can be changed (or set) at runtime using `Facebook.set_app_secret("<app secret>")`.
+
+If you supply the `app_secret`, an [appsecret_proof](https://developers.facebook.com/docs/graph-api/securing-requests) will be submitted along with the Graph API requests. The `app_secret` can be changed (or set) at runtime using `Facebook.set_app_secret("<app secret>")`.
+
+You can also configure `facebook.ex` library in runtime using `{:system, _}` tuples:
+
+```
+config :facebook,
+  app_id: {:system, "APP_ID"},
+  app_secret: {:system, "APP_SECRET"},
+  app_access_token: {:system, "APP_ACCESS_TOKEN"},
+  graph_url: {:system, "GRAPH_URL"},
+  graph_video_url: {:system, "GRAPH_VIDEO_URL"},
+  request_conn_timeout: {:system, :integer, "REQUEST_CONN_TIMEOUT"},
+  request_recv_timeout: {:system, :integer, "REQUEST_RECV_TIMEOUT"}
+```
+
+Note that if you use `{:system, _}` (or `{:system, :integer, _}`) tuple but don't provide the corresponding
+environment variable application will crash on startup to prevent unexpected behaviour later.
 
 ## Usage
 

--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -1,32 +1,22 @@
 defmodule Facebook do
-  use Application
-  use Supervisor
-
   @moduledoc """
   Provides API wrappers for the Facebook Graph API
 
   See: https://developers.facebook.com/docs/graph-api
   """
 
+  use Application
+
   alias Facebook.Config
   alias Facebook.GraphAPI
   alias Facebook.GraphVideoAPI
   alias Facebook.ResponseFormatter
 
-  @doc "Start hook"
   def start(_type, _args) do
-    start_link([])
-  end
+    children = [Config]
+    opts = [strategy: :one_for_one, name: Facebook.Supervisor]
 
-  @doc "Supervisor start"
-  def start_link(_) do
-    Supervisor.start_link(__MODULE__, [])
-  end
-
-  def init(_) do
-    children = []
-
-    supervise(children, strategy: :one_for_one)
+    Supervisor.start_link(children, opts)
   end
 
   @typedoc """

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -1,32 +1,51 @@
 defmodule Facebook.Config do
   @moduledoc """
-  Config helpers
+  Reads configuration on application start, parses all environment variables (if any)
+  and caches the final config in memory to avoid parsing on each read afterwards.
   """
 
-  # URL to the Facebook Graph including the version.
-  def graph_url do
-    Application.fetch_env!(:facebook, :graph_url)
+  use GenServer
+
+  @config_keys ~w(
+    graph_url
+    graph_video_url
+    app_id
+    appsecret
+    app_secret
+    app_access_token
+    request_conn_timeout
+    request_recv_timeout
+  )a
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(_opts) do
+    config =
+      @config_keys
+      |> Enum.map(fn key -> {key, get_config_value(key)} end)
+      |> Map.new()
+
+    {:ok, config}
   end
 
-  def graph_video_url do
-    Application.fetch_env!(:facebook, :graph_video_url)
-  end
+  # URL to the Facebook Graph including the version
+  def graph_url, do: get(:graph_url)
+
+  def graph_video_url, do: get(:graph_video_url)
+
+  # App id, a.k.a. client id
+  def app_id, do: get(:app_id)
 
   # App secret a.k.a. client secret
-  def appsecret do
-    IO.warn(
-      "'appsecret' method is deprecated. Please use 'app_secret'",
-      Macro.Env.stacktrace(__ENV__)
-    )
-
-    app_secret()
-  end
+  @deprecated "Use app_secret/0 instead"
+  def appsecret, do: app_secret()
 
   def app_secret do
-    with :error <- Application.fetch_env(:facebook, :appsecret) do
-      Application.fetch_env!(:facebook, :app_secret)
+    with nil <- get(:appsecret) do
+      get(:app_secret)
     else
-      {:ok, secret} ->
+      secret ->
         IO.warn(
           "'appsecret' configuration value is deprecated. Please use 'app_secret'",
           Macro.Env.stacktrace(__ENV__)
@@ -36,47 +55,60 @@ defmodule Facebook.Config do
     end
   end
 
-  def appsecret(appsecret) do
-    IO.warn(
-      "'appsecret' method value is deprecated. Please use 'app_secret'",
-      Macro.Env.stacktrace(__ENV__)
-    )
-
-    app_secret(appsecret)
-  end
+  @deprecated "Use app_secret/1 instead"
+  def appsecret(appsecret), do: app_secret(appsecret)
 
   def app_secret(app_secret) do
-    case Application.fetch_env(:facebook, :appsecret) do
-      {:ok, _} ->
+    case get(:appsecret) do
+      nil ->
+        put(:app_secret, app_secret)
+
+      _ ->
         IO.warn(
           "'appsecret' configuration value is deprecated. Please use 'app_secret'",
           Macro.Env.stacktrace(__ENV__)
         )
 
-        Application.put_env(:facebook, :appsecret, app_secret)
-
-      _ ->
-        Application.put_env(:facebook, :app_secret, app_secret)
+        put(:appsecret, app_secret)
     end
   end
 
-  # App id, a.k.a. client id
-  def app_id do
-    Application.fetch_env!(:facebook, :app_id)
-  end
-
   # App access token
-  def app_access_token do
-    Application.fetch_env!(:facebook, :app_access_token)
-  end
+  def app_access_token, do: get(:app_access_token)
 
   # Request conn_timeout
-  def request_conn_timeout do
-    Application.fetch_env(:facebook, :request_conn_timeout)
-  end
+  def request_conn_timeout, do: get(:request_conn_timeout)
 
   # Request recv_timeout
-  def request_recv_timeout do
-    Application.fetch_env(:facebook, :request_recv_timeout)
+  def request_recv_timeout, do: get(:request_recv_timeout)
+
+  def get(key), do: GenServer.call(__MODULE__, {:get, key})
+
+  def put(key, value), do: GenServer.call(__MODULE__, {:put, key, value})
+
+  @impl true
+  def handle_call({:get, key}, _from, state) do
+    {:reply, Map.get(state, key), state}
   end
+
+  @impl true
+  def handle_call({:put, key, value}, _from, state) do
+    {:reply, value, Map.put(state, key, value)}
+  end
+
+  defp get_config_value(key) do
+    :facebook
+    |> Application.get_env(key)
+    |> parse_config_value()
+  end
+
+  defp parse_config_value({:system, env_name}), do: System.fetch_env!(env_name)
+
+  defp parse_config_value({:system, :integer, env_name}) do
+    env_name
+    |> System.fetch_env!()
+    |> String.to_integer()
+  end
+
+  defp parse_config_value(value), do: value
 end

--- a/lib/facebook/config.ex
+++ b/lib/facebook/config.ex
@@ -102,13 +102,25 @@ defmodule Facebook.Config do
     |> parse_config_value()
   end
 
-  defp parse_config_value({:system, env_name}), do: System.fetch_env!(env_name)
+  defp parse_config_value({:system, env_name}), do: fetch_env!(env_name)
 
   defp parse_config_value({:system, :integer, env_name}) do
     env_name
-    |> System.fetch_env!()
+    |> fetch_env!()
     |> String.to_integer()
   end
 
   defp parse_config_value(value), do: value
+
+  # System.fetch_env!/1 support for older versions of Elixir
+  defp fetch_env!(env_name) do
+    case System.get_env(env_name) do
+      nil ->
+        raise ArgumentError,
+          message: "could not fetch environment variable \"#{env_name}\" because it is not set"
+
+      value ->
+        value
+    end
+  end
 end

--- a/lib/facebook/graph_api.ex
+++ b/lib/facebook/graph_api.ex
@@ -8,12 +8,12 @@ defmodule Facebook.GraphAPI do
   def process_request_options(options) do
     updated_options =
       case Config.request_conn_timeout() do
-        :error -> options
+        nil -> options
         val -> options ++ [timeout: val]
       end
 
     case Config.request_recv_timeout() do
-      :error -> updated_options
+      nil -> updated_options
       val -> updated_options ++ [recv_timeout: val]
     end
   end
@@ -22,8 +22,5 @@ defmodule Facebook.GraphAPI do
 
   def process_url(url), do: Config.graph_url() <> url
 
-  def process_response_body(body) do
-    body
-    |> JSON.decode()
-  end
+  def process_response_body(body), do: JSON.decode(body)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,9 @@ defmodule Facebook.Mixfile do
         graph_video_url: "https://graph-video.facebook.com",
         app_secret: nil,
         app_id: nil,
-        app_access_token: nil
+        app_access_token: nil,
+        request_conn_timeout: nil,
+        request_recv_timeout: nil
       ]
     ]
   end

--- a/test/facebook/config_test.exs
+++ b/test/facebook/config_test.exs
@@ -1,0 +1,94 @@
+defmodule Facebook.ConfigTest do
+  use ExUnit.Case, async: false
+
+  alias Facebook.Config
+
+  describe "init/1" do
+    test "uses default values when no other values are specified" do
+      :ok = Application.stop(:facebook)
+      {:ok, _} = Application.ensure_all_started(:facebook)
+      assert Config.graph_url() == "https://graph.facebook.com"
+      assert Config.request_conn_timeout() == nil
+    end
+
+    test "uses values from config when they are present" do
+      :ok = Application.stop(:facebook)
+
+      set_config(%{
+        graph_url: "https://graph.facebook.com/v1",
+        request_conn_timeout: 100
+      })
+
+      {:ok, _} = Application.ensure_all_started(:facebook)
+
+      assert Config.graph_url() == "https://graph.facebook.com/v1"
+      assert Config.request_conn_timeout() == 100
+    end
+
+    test "reads environment variables when {:system, _} tuple is used" do
+      :ok = Application.stop(:facebook)
+
+      set_config(%{
+        graph_url: {:system, "GRAPH_URL"},
+        request_conn_timeout: {:system, :integer, "REQUEST_CONN_TIMEOUT"}
+      })
+
+      set_envs(%{
+        "GRAPH_URL" => "https://graph.facebook.com/v1",
+        "REQUEST_CONN_TIMEOUT" => "100"
+      })
+
+      {:ok, _} = Application.ensure_all_started(:facebook)
+
+      assert Config.graph_url() == "https://graph.facebook.com/v1"
+      assert Config.request_conn_timeout() == 100
+    end
+
+    test "fails to start when {:system, _} tuple is used but env is missing" do
+      :ok = Application.stop(:facebook)
+
+      set_config(%{
+        graph_url: {:system, "GRAPH_URL"},
+        request_conn_timeout: {:system, :integer, "REQUEST_CONN_TIMEOUT"}
+      })
+
+      assert {:error,
+              {:facebook,
+               {{:shutdown,
+                 {:failed_to_start_child, Facebook.Config,
+                  {%ArgumentError{
+                     message:
+                       "could not fetch environment variable \"GRAPH_URL\" because it is not set"
+                   }, _}}},
+                {Facebook, :start, [:normal, []]}}}} = Application.ensure_all_started(:facebook)
+    end
+  end
+
+  defp set_config(values) do
+    original_config = Application.get_all_env(:facebook)
+
+    for {key, value} <- values do
+      Application.put_env(:facebook, key, value)
+    end
+
+    on_exit(fn ->
+      for {key, _value} <- values do
+        Application.put_env(:facebook, key, Keyword.get(original_config, key))
+      end
+
+      {:ok, _} = Application.ensure_all_started(:facebook)
+    end)
+  end
+
+  defp set_envs(envs) do
+    for {key, value} <- envs do
+      System.put_env(key, value)
+    end
+
+    on_exit(fn ->
+      for {key, _value} <- envs do
+        System.delete_env(key)
+      end
+    end)
+  end
+end

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -527,7 +527,11 @@ defmodule FacebookTest do
   end
 
   describe "signing" do
-    Facebook.set_app_secret(@app_secret)
+    setup do
+      Facebook.set_app_secret(@app_secret)
+
+      :ok
+    end
 
     test "payload" do
       payload = JSON.encode!(%{id: @payment_id})


### PR DESCRIPTION
Compile-time configuration doesn't work well with OTP releases, so I added runtime configuration support for all config keys.