### PR TITLE
Fix Dialyzer issues 

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -43,8 +43,10 @@ defmodule Facebook do
 
   @typedoc """
   Query values used for supplying or requesting edge attributes.
+  Fields are represented as a string of comma separated values.
+  For example, "id,first_name"
   """
-  @type fields :: list
+  @type fields :: String.t()
 
   @typedoc """
   Relative path to media file.
@@ -144,20 +146,12 @@ defmodule Facebook do
       iex> Facebook.me("id,first_name", "<Access Token>")
       {:ok, %{"first_name" => "...", "id" => "..."}}
 
-      iex> Facebook.me([fields: "id,first_name"], "<Access Token>")
-      {:ok, %{"first_name" => "...", "id" => "..."}}
-
   See: https://developers.facebook.com/docs/graph-api/reference/user/
   """
-  @spec me(fields :: String.t(), access_token) :: resp
-  def me(fields, access_token) when is_binary(fields) do
-    me([fields: fields], access_token)
-  end
-
   @spec me(fields, access_token) :: resp
   def me(fields, access_token) do
     params =
-      fields
+      [fields: fields]
       |> add_app_secret(access_token)
       |> add_access_token(access_token)
 
@@ -390,9 +384,9 @@ defmodule Facebook do
 
   See: https://developers.facebook.com/docs/graph-api/reference/page/
   """
-  @spec fan_count(page_id, access_token) :: integer
+  @spec fan_count(page_id, access_token) :: resp
   def fan_count(page_id, access_token) do
-    page(page_id, access_token, ["fan_count"])
+    page(page_id, access_token, "fan_count")
   end
 
   @doc """
@@ -462,7 +456,7 @@ defmodule Facebook do
   """
   @spec page(page_id, access_token) :: resp
   def page(page_id, access_token) do
-    page(page_id, access_token, [])
+    page(page_id, access_token, "")
   end
 
   @doc """
@@ -476,7 +470,7 @@ defmodule Facebook do
   """
   @spec page(page_id, access_token, fields) :: resp
   def page(page_id, access_token, fields) do
-    params = [fields: Enum.join(fields, ",")]
+    params = [fields: fields]
     get_object(page_id, access_token, params)
   end
 

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -373,7 +373,7 @@ defmodule FacebookTest do
                 %{
                   "id" => id,
                   "about" => about
-                }} = Facebook.page(@page_id, app_access_token, ["about"])
+                }} = Facebook.page(@page_id, app_access_token, "about")
 
         assert(String.length(about) > 0)
         assert(id == Integer.to_string(@page_id, 10))
@@ -386,7 +386,7 @@ defmodule FacebookTest do
                  Facebook.page(
                    @page_id,
                    invalid_access_token,
-                   ["about"]
+                   "about"
                  )
       end
     end


### PR DESCRIPTION
I've ran a Dialyzer and found out that typespecs are messed up and similar functions use different conventions for fields (mostly it is a string with comma separated values but sometimes it is a list of strings).

I updated typepecs and unified fields usage.