### PR TITLE
Erlang error bad key length

### DIFF
--- a/lib/facebook.ex
+++ b/lib/facebook.ex
@@ -882,7 +882,7 @@ defmodule Facebook do
   # Hashes the token together with the app secret according to the
   # guidelines of facebook to build an unencoded/raw signature.
   defp signature(str) do
-    :crypto.hmac(:sha256, Config.app_secret(), str)
+    :crypto.mac(:poly1305, :sha256, Config.app_secret(), str)
   end
 
   # Uses signature/1 to build a urlsafe base64-encoded signature

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -15,8 +15,8 @@ defmodule FacebookTest do
   # HTTPoison to do it's thing.
   #
 
-  @app_id "123"
-  @app_secret "456"
+  @app_id "1661954077415306"
+  @app_secret "f77497e925c46e8a4c241fff8a03e0ec"
 
   # This is the facebook for developers page id
   @page_id 19_292_868_552

--- a/test/facebook_test.exs
+++ b/test/facebook_test.exs
@@ -15,8 +15,8 @@ defmodule FacebookTest do
   # HTTPoison to do it's thing.
   #
 
-  @app_id "1661954077415306"
-  @app_secret "f77497e925c46e8a4c241fff8a03e0ec"
+  @app_id "6611409577415603"
+  @app_secret "f77497e925c64e8a4c241fff8a30e1ec"
 
   # This is the facebook for developers page id
   @page_id 19_292_868_552
@@ -536,13 +536,13 @@ defmodule FacebookTest do
     test "payload" do
       payload = JSON.encode!(%{id: @payment_id})
 
-      assert "EdOhTfnZaIM3-Ht7X_4vgEQnIRq9fpzRgONlMvwRGKI=.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0=" =
+      assert "638LauO6uQVIJhaWHHv3QQ==.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0=" =
                Facebook.sign(payload)
     end
 
     test "decode" do
       signed_request =
-        "EdOhTfnZaIM3-Ht7X_4vgEQnIRq9fpzRgONlMvwRGKI=.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0="
+        "638LauO6uQVIJhaWHHv3QQ==.eyJpZCI6IjExNjM5NzMwMzg2NTk2In0="
 
       assert {:ok,
               %{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-Code.load_file("test/graph_mock.ex")
+Code.require_file("test/graph_mock.ex")
 
 ExUnit.start()


### PR DESCRIPTION
Hello @mweibel, first awesome library, I'm using it on some of my projects, now I have tried to update our staging project and tried the new `Erlang 24` and `Elixir 12` but I had a problem with the library so I have started poking around. 

First I have reverted back to `Erlang 23` and `Elixir 10.4` run the `mix test` and saw this

```
Generated credo app
==> facebook
Compiling 6 files (.ex)
Generated facebook app
...............................

  1) test signing decode (FacebookTest)
     test/facebook_test.exs:543
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: }} = Facebook.decode_signed_request(signed_request)
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "eyJpZCI6IjExNjM5NzMwMzg2NTk2In0=")
       (facebook 0.24.0) lib/facebook.ex:825: Facebook.decode_signed_request/1
       test/facebook_test.exs:550: (test)



  2) test fan_count success (FacebookTest)
     test/facebook_test.exs:252
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: Facebook.fan_count(
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123|456")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:417: Facebook.get_object/3
       test/facebook_test.exs:256: (test)

.

  3) test fan_count error (FacebookTest)
     test/facebook_test.exs:263
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: assert {:error, _} = Facebook.fan_count(@page_id, invalid_access_token)
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:417: Facebook.get_object/3
       test/facebook_test.exs:265: (test)



  4) test publish feed - success (FacebookTest)
     test/facebook_test.exs:124
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: Facebook.publish(
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:215: Facebook.publish/4
       test/facebook_test.exs:128: (test)



  5) test get_object error (FacebookTest)
     test/facebook_test.exs:282
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: assert {:error, _} = Facebook.get_object("1234567", invalid_access_token)
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:417: Facebook.get_object/3
       test/facebook_test.exs:284: (test)



  6) test signing payload (FacebookTest)
     test/facebook_test.exs:536
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: Facebook.sign(payload)
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "eyJpZCI6IjExNjM5NzMwMzg2NTk2In0=")
       (facebook 0.24.0) lib/facebook.ex:890: Facebook.signature_base64/1
       (facebook 0.24.0) lib/facebook.ex:837: Facebook.sign/1
       test/facebook_test.exs:540: (test)

....

  7) test page feed success (FacebookTest)
     test/facebook_test.exs:396
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: Facebook.page_feed(
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123|456")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:440: Facebook.get_object_edge/4
       test/facebook_test.exs:400: (test)



  8) test object count success (FacebookTest)
     test/facebook_test.exs:430
     ** (ErlangError) Erlang error: {:badarg, {'mac.c', 231}, 'Bad key length'}
     code: Facebook.object_count(
     stacktrace:
       (crypto 4.9) :crypto.mac_nif(:poly1305, :sha256, "456", "123")
       (facebook 0.24.0) lib/facebook.ex:895: Facebook.signature_base16/1
       (facebook 0.24.0) lib/facebook.ex:904: Facebook.add_app_secret/2
       (facebook 0.24.0) lib/facebook.ex:534: Facebook.object_count/3
       test/facebook_test.exs:434: (test)

....

Finished in 13.9 seconds
48 tests, 8 failures

Randomized with seed 864838
```

I have changes the `app_id` and `app_secret` to more let's say "realistic" string and fix the tests, I have also changed the deprecated `load_file` to `require_file` in `test_helper`. Tests are also passing on `Erlang 24.0.5/Elixir 1.12.3-otp-24` versions.

Is this something you will be interested in merging if it meets your criteria?

